### PR TITLE
Php8.2 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## Changelog ##
 
+### 1.1.3 ###
+* Update: Fix PHP 8.2 Deprecation notices by updated Boldgrid/Library.
+
 ### 1.1.2 ###
 * Bug fix: Use internal get_page_by_title method since WP 6.2 deprecated the function.
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,13 @@
             "Boldgrid\\Inspirations\\Premium\\": "src/Premium"
         }
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/boldgrid/library"
+        }
+    ],
     "require": {
-        "boldgrid/library": "^2.0.0"
+        "boldgrid/library": "dev-php8.2-fixes"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,7 @@
             "Boldgrid\\Inspirations\\Premium\\": "src/Premium"
         }
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/boldgrid/library"
-        }
-    ],
     "require": {
-        "boldgrid/library": "dev-php8.2-fixes"
+        "boldgrid/library": "^2.13.11"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb1fb6e0c2b0695abc83028902ddf0ea",
+    "content-hash": "521e0c765f06fba019a990556ab02d40",
     "packages": [
         {
             "name": "boldgrid/library",
-            "version": "dev-php8.2-fixes",
+            "version": "2.13.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/boldgrid/library",
-                "reference": "1c043150ddcc12325a5f474f6c9f0aca9ef17732"
+                "url": "https://github.com/BoldGrid/library.git",
+                "reference": "ec1da4d4a6029968407b8f04c61417af4f5e4487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BoldGrid/library/zipball/ec1da4d4a6029968407b8f04c61417af4f5e4487",
+                "reference": "ec1da4d4a6029968407b8f04c61417af4f5e4487",
+                "shasum": ""
             },
             "require-dev": {
                 "yoast/phpunit-polyfills": "^1.0"
@@ -23,11 +29,7 @@
                     "Boldgrid\\Library\\Util\\": "src/Util"
                 }
             },
-            "scripts": {
-                "post-autoload-dump": [
-                    "yarn && yarn run cpx 'node_modules/jquery-toggles/toggles.min.js' 'build/' && yarn run cpx 'node_modules/jquery-toggles/css/toggles-full.css' 'build/' && yarn run rimraf node_modules"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
@@ -55,15 +57,13 @@
                 }
             ],
             "description": "The BoldGrid Library for shared code used in official BoldGrid plugins and themes.",
-            "time": "2023-05-22T18:45:37+00:00"
+            "time": "2023-05-23T20:04:34+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "boldgrid/library": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1,27 +1,21 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f420caf1f3ed536baae0728499079902",
+    "content-hash": "cb1fb6e0c2b0695abc83028902ddf0ea",
     "packages": [
         {
             "name": "boldgrid/library",
-            "version": "dev-dev",
+            "version": "dev-php8.2-fixes",
             "source": {
                 "type": "git",
-                "url": "https://github.com/BoldGrid/library.git",
-                "reference": "ab85752d51a3baf3d5a519381f85ed2a6a392b11"
+                "url": "https://github.com/boldgrid/library",
+                "reference": "1c043150ddcc12325a5f474f6c9f0aca9ef17732"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/BoldGrid/library/zipball/ab85752d51a3baf3d5a519381f85ed2a6a392b11",
-                "reference": "ab85752d51a3baf3d5a519381f85ed2a6a392b11",
-                "shasum": ""
-            },
-            "require": {
-                "timelsass/wp-php-version-check": "^1.0.0"
+            "require-dev": {
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -29,9 +23,13 @@
                     "Boldgrid\\Library\\Util\\": "src/Util"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "post-autoload-dump": [
+                    "yarn && yarn run cpx 'node_modules/jquery-toggles/toggles.min.js' 'build/' && yarn run cpx 'node_modules/jquery-toggles/css/toggles-full.css' 'build/' && yarn run rimraf node_modules"
+                ]
+            },
             "license": [
-                "GPL2.0"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -46,7 +44,9 @@
                     "role": "Developer"
                 },
                 {
-                    "name": "Joe",
+                    "name": "Joe Cartonia",
+                    "email": "joec@boldgrid.com",
+                    "homepage": "https://twitter.com/joemotocss",
                     "role": "Developer"
                 },
                 {
@@ -55,37 +55,7 @@
                 }
             ],
             "description": "The BoldGrid Library for shared code used in official BoldGrid plugins and themes.",
-            "time": "2017-05-30 21:10:04"
-        },
-        {
-            "name": "timelsass/wp-php-version-check",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/timelsass/wp-php-version-check.git",
-                "reference": "072c97eec9e4b35db04aee8818bd35636da6c33f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/timelsass/wp-php-version-check/zipball/072c97eec9e4b35db04aee8818bd35636da6c33f",
-                "reference": "072c97eec9e4b35db04aee8818bd35636da6c33f",
-                "shasum": ""
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Tim Elsass",
-                    "email": "dev@tim.ph",
-                    "homepage": "http://tim.ph",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Composer package to verify that WordPress and PHP versions satisfy a minimum version requirement.",
-            "time": "2017-05-03T22:51:07+00:00"
+            "time": "2023-05-22T18:45:37+00:00"
         }
     ],
     "packages-dev": [],
@@ -97,5 +67,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This resolves a handful of PHP8.2 Deprecated warnings. Mostly, it is resolving the following:
* Adding dynamic properties is deprecated
* strpos() argument 1 cannot be null

These resolutions are made through the updated Boldgrid/Library